### PR TITLE
Update peer dependencies

### DIFF
--- a/projects/ngx-text-diff/package.json
+++ b/projects/ngx-text-diff/package.json
@@ -22,10 +22,10 @@
     "diff-match-patch": "^1.0.4"
   },
   "peerDependencies": {
-    "@angular/common": ">=6.0.0",
-    "@angular/core": "^>=6.0.0",
-    "@angular/forms": "^>=6.0.0",
-    "@angular/cdk": "^>=6.0.0",
+    "@angular/common": ">=9.0.0",
+    "@angular/core": "^>=9.0.0",
+    "@angular/forms": "^>=9.0.0",
+    "@angular/cdk": "^>=9.0.0",
     "rxjs": "~6.3.3"
   }
 }


### PR DESCRIPTION
The latest version of this library supports Angular 9, but due to no update of `peerDependencies` in the `package.json`, the `npm install` warns about peer deps not being installed.

Solves #49